### PR TITLE
Parse EDIDs directly, rather than execing out to edid-decode.

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,7 +14,7 @@ import (
 // not have a serial number).
 type Display struct {
 	Name       string `json:"name"`
-	Serial     string `json:"serial,omitempty"`
+	Serial     uint32 `json:"serial,omitempty"`
 	IsLaptop   bool   `json:"is-laptop,omitempty"`
 	connected  bool   // connected indicates whether this Display has been detected.
 	xrandrName string // xrandrName matches this Display with xrandr.

--- a/xrandr.go
+++ b/xrandr.go
@@ -76,7 +76,7 @@ func detectDisplays() map[string]struct{} {
 	return allDisplays
 }
 
-func noteConnectedDisplay(xrandrName, serial string, isLaptop bool) {
+func noteConnectedDisplay(xrandrName string, serial uint32, isLaptop bool) {
 	for i := range Config.Displays {
 		display := &Config.Displays[i]
 		if display.Serial == serial && display.IsLaptop == isLaptop {
@@ -87,7 +87,7 @@ func noteConnectedDisplay(xrandrName, serial string, isLaptop bool) {
 			return
 		}
 	}
-	log.Printf("display %q (serial %s, isLaptop %v) not found in config\n",
+	log.Printf("display %q (serial %d, isLaptop %v) not found in config\n",
 		xrandrName, serial, isLaptop)
 }
 


### PR DESCRIPTION
This is probably faster, but, more importantly, it eliminates a dependency that isn't easy to obtain in all distros.